### PR TITLE
Fix datatables syntax

### DIFF
--- a/client/lib/page_count.js
+++ b/client/lib/page_count.js
@@ -8,7 +8,7 @@ var PageTable = require('./page_table.js');
 var DisplayError = require('./alerts.js').prototype.DisplayError;
 var concordance_utils = require('./concordance_utils.js');
 
-var renderNumeric = DataTable.render.number;
+var renderNumeric = DataTable.render.number();
 
 // PageChapter inherits PageTable
 function PageChapter() {

--- a/server/requirements-to-freeze.txt
+++ b/server/requirements-to-freeze.txt
@@ -1,8 +1,7 @@
 flake8
 coverage
 psycopg2-binary
-# NB: This restriction is to allow pybtex to install
-setuptools>=75.0.0,<82
+setuptools>=75.0.0
 wheel
 -e .
 -e .[testing]

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -41,7 +41,7 @@ pillow==11.1.0
 pluggy==1.5.0
 psycopg2==2.9.9
 psycopg2-binary==2.9.9
-pybtex==0.24.0
+pybtex==0.25.1
 pycodestyle==2.12.1
 pyflakes==3.2.0
 PyICU==2.13.1


### PR DESCRIPTION
DataTable.render.number became a factory after the dataTables.net upgrade. Call renderNumeric using the defaults.