### PR TITLE
docs: Add sphinxcontrib.youtube, example video

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -53,6 +53,7 @@ extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.autosectionlabel',
     'sphinx.ext.extlinks',
+    'sphinxcontrib.youtube',
 ]
 suppress_warnings = ['autosectionlabel.*']  # Tries to generate duplicate labels
 

--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -7,6 +7,8 @@ study of narrative fiction. It started off with the
 project and now contains a range of fictional texts from children's
 literature to German novels (all out of copyright).
 
+..  youtube:: yv6OP3W2NDE
+
 This guide covers information on how to use CLiC, developer features,
 information on the corpora and legal & technical details. For inspiration
 on what to do with CLiC, the

--- a/docs/requirements-to-freeze.txt
+++ b/docs/requirements-to-freeze.txt
@@ -1,1 +1,2 @@
 sphinx
+sphinxcontrib-youtube

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -19,4 +19,5 @@ sphinxcontrib-htmlhelp==2.1.0
 sphinxcontrib-jsmath==1.0.1
 sphinxcontrib-qthelp==2.0.0
 sphinxcontrib-serializinghtml==2.0.0
+sphinxcontrib-youtube==1.5.0
 urllib3==2.5.0


### PR DESCRIPTION
Use the sphinxcontrib.youtube to make it easy to embed videos, add an example video in introduction.rst.