### PR TITLE
client/filesystem: Use papa-parse for CSV I/O

### DIFF
--- a/client/lib/filesystem.js
+++ b/client/lib/filesystem.js
@@ -2,6 +2,7 @@
 /*jslint todo: true, regexp: true, browser: true, unparam: true, plusplus: true */
 /*global Promise, Blob, FileReader */
 var FileSaver = require('file-saver');
+var Papa = require('papaparse');
 
 module.exports.format_dt = function (dt) {
     var out = [], row = [],
@@ -50,38 +51,34 @@ module.exports.format_dt = function (dt) {
   * Save (data), probably from format_dt(), to disk
   */
 module.exports.save = function (data) {
-    var blob, filename = window.location.pathname.replace('/', 'clic-') + '.csv';
+    var csv, blob, filename = window.location.pathname.replace('/', 'clic-') + '.csv';
 
-    blob = new Blob(data.map(function (d) {
-        return d.map(function (val) {
-            return '"' + (val || '').toString().replace(/"/g, '""').replace(/\n{2,}/g, "¶ ").replace(/\n+/g, ' ') + '"';
-        }).join(',') + '\r\n';
-    }), { type: "text/csv;charset=utf-8" });
+    csv = Papa.unparse(data.map(function (row) {
+        return row.map(function (val) {
+            return (val || '').toString().replace(/\n{2,}/g, "¶ ").replace(/\n+/g, ' ');
+        });
+    }), { newline: '\r\n' });
+    // Prepend a UTF-8 BOM so Excel opens the file as Unicode
+    blob = new Blob([Papa.BYTE_ORDER_MARK + csv], { type: "text/csv;charset=utf-8" });
     FileSaver.saveAs(blob, filename);
 };
 
 /** Turn a CSV file into state object **/
 module.exports.file_to_state = function (file) {
-    var i, header,
+    var i, header, rows,
         tag_column_offset = null,
-        lines = file.split('\r\n'),
         tag_columns = {},
         tag_column_order = [];
 
-    // Turn a CSV line string into an array of values
-    function parse_line(line) {
-        return line.split(/^"|","|"$/).slice(1, -1).map(function (val) {
-            return val.replace(/""/g, '"');
-        });
+    // Is the file actually JSON?
+    if (file.startsWith("{") && file.endsWith("}")) {
+        return JSON.parse(file);
     }
 
-    // Is the file actually JSON?
-    if (lines.length === 1 && lines[0].startsWith("{") && lines[0].endsWith("}")) {
-        return JSON.parse(lines.join("\r\n"));
-    }
+    rows = Papa.parse(file, { skipEmptyLines: true }).data;
+    header = rows[0] || [];
 
     // Find tags in header
-    header = parse_line(lines[0]);
     for (i = 0; i < header.length; i++) {
         if (header[i].indexOf("tag:") === 0) {
             if (tag_column_offset === null) {
@@ -93,8 +90,8 @@ module.exports.file_to_state = function (file) {
     }
 
     // Populate tag values if any where found
-    (tag_column_offset !== null ? lines.splice(1) : []).map(function (line_str) {
-        var j, line = parse_line(line_str);
+    (tag_column_offset !== null ? rows.slice(1) : []).map(function (line) {
+        var j;
 
         for (j = 0; j < tag_column_order.length; j++) {
             if (line[tag_column_offset + j] > ' ') {

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -17,6 +17,7 @@
         "jquery": "^3.5.0",
         "nouislider": "^15.8.1",
         "nunjucks": "^3.2.4",
+        "papaparse": "^5.5.4",
         "tom-select": "^2.4.3",
         "unidecode": "^1.1.0"
       },
@@ -3361,6 +3362,11 @@
       "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
       "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
       "dev": true
+    },
+    "node_modules/papaparse": {
+      "version": "5.5.4",
+      "resolved": "https://registry.npmjs.org/papaparse/-/papaparse-5.5.4.tgz",
+      "integrity": "sha512-SwzWD9gl/ElwYLCI0nUja1mFJzjq2D8ziShfNBa7zCHzkOozeOGDwHWQ+tvCzEZcewecWZ5U7kUopDnG+DFYEQ=="
     },
     "node_modules/parents": {
       "version": "1.0.1",

--- a/client/package.json
+++ b/client/package.json
@@ -12,6 +12,7 @@
     "jquery": "^3.5.0",
     "nouislider": "^15.8.1",
     "nunjucks": "^3.2.4",
+    "papaparse": "^5.5.4",
     "tom-select": "^2.4.3",
     "unidecode": "^1.1.0"
   },

--- a/client/tests/test_filesystem.js
+++ b/client/tests/test_filesystem.js
@@ -3,6 +3,7 @@
 /*global Promise */
 var test = require('tape');
 var proxyquire =  require('proxyquire');
+var Papa = require('papaparse');
 
 var last_saved = {};
 
@@ -19,6 +20,12 @@ var filesystem = proxyquire.noCallThru().load('lib/filesystem.js', {
 });
 
 
+var example_csv = [
+    'ID,,Left,Node,Right,Book,In bk.,tag:bling,tag:bleu,f25a738,https://clic-fiction.com/concordance?conc-q=cloud%20*%20on&conc-subset=all&conc-type=whole&corpora=corpus%3ADNov&kwic-span=-5%3A5&table-filter=&table-type=basic',
+    'DC:622085:622102,"cloud, ,lowering, ,on,0,2,4",seemed to have left the Doctor\'s roof with a dark ,cloud lowering on, it. The reverence that I had for his grey head,DC,622085/1937052,✓,✓,,',
+    'OMF:424624:424636,"cloud,, ,so, ,on,0,2,4",business. ¶ As on the Secretary\'s face there was a nameless ,"cloud, so on", his manner there was a shadow equally indefinable. It was,OMF,424624/1818145,✓,✓,,',
+    'TTC:54361:54377,"cloud, ,settled, ,on,0,2,4",would be red upon many there. ¶ And now that the ,cloud settled on," Saint Antoine, which a momentary gleam had driven from his",TTC,54361/758806,✓, ,,',
+].join('\n');
 
 test('file_to_state', function (t) {
     global.window.location = { pathname: 'ut-path' };
@@ -32,6 +39,26 @@ test('file_to_state', function (t) {
         "doc": "/flexiconc",
         "args": {"a": 1},
         "state": {"b": 2},
+    });
+
+    // CSV headers are parsed for tag columns; the query part of the URL is preserved
+    t.deepEqual(filesystem.file_to_state(example_csv), {
+        url: '/concordance?conc-q=cloud%20*%20on&conc-subset=all&conc-type=whole&corpora=corpus%3ADNov&kwic-span=-5%3A5&table-filter=&table-type=basic',
+        state: {
+            tag_columns: {
+                // Only rows with a non-whitespace tag value are recorded
+                bling: {
+                    'DC:622085:622102': true,
+                    'OMF:424624:424636': true,
+                    'TTC:54361:54377': true,
+                },
+                bleu: {
+                    'DC:622085:622102': true,
+                    'OMF:424624:424636': true,
+                },
+            },
+            tag_column_order: ['bling', 'bleu'],
+        },
     });
 
     t.end();
@@ -50,14 +77,15 @@ test('save', function (t) {
         ['There were "five" carrots', 'left in the bag'],  // Quotes escaped
         ['a', 'b\n\nc\nd'],  // Paragraphs escaped to ¶
     ]);
+    last_saved.content = last_saved.content.join("").split("\r\n");
     t.deepEqual(last_saved, {
         filename: 'ut-path.csv',
         type: { type: 'text/csv;charset=utf-8' },
         content: [
-            // Quotes within values get escaped
-            '"There were ""five"" carrots","left in the bag"\r\n',
+            // Leading UTF-8 BOM so Excel opens as Unicode; quotes within values get escaped
+            Papa.BYTE_ORDER_MARK + '"There were ""five"" carrots",left in the bag',
             // End-paragraphs get a ¶, just newlines are ignored
-            '"a","b¶ c d"\r\n',
+            'a,b¶ c d',
         ],
     });
 


### PR DESCRIPTION
Our built-in parser is no longer enough to read files saved in libreoffice. Switch it out to a grown-up parser.

Fixes #98