### PR TITLE
Resurrect int-test workflow for test

### DIFF
--- a/.github/workflows/int-test.yaml
+++ b/.github/workflows/int-test.yaml
@@ -5,11 +5,11 @@ on:
   push:
     branches:
       - '[0-9]+\.[0-9]+'
-      - 'development'
+      - 'test'
   pull_request:
     branches:
       - '[0-9]+\.[0-9]+'
-      - 'development'
+      - 'test'
 
 name: int-test
 

--- a/.github/workflows/int-test.yaml
+++ b/.github/workflows/int-test.yaml
@@ -39,6 +39,20 @@ jobs:
           fetch-tags: true
       - name: Install prerequisites
         run: sudo ./prerequisites.sh
+      - name: Cache pip downloads
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt', '**/requirements-to-freeze.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+      - name: Cache npm downloads
+        uses: actions/cache@v4
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-npm-${{ hashFiles('client/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-npm-
       - name: Create config file
         # NB: Full hostname is too long for a self-signed cert
         run: |

--- a/client/install.sh
+++ b/client/install.sh
@@ -71,7 +71,7 @@ upstream uwsgi_${PROJECT_NAME}_server {
 
 # NB: inactive items get thrown away entirely, uwsgi_cache_background_update
 # won't save us.
-uwsgi_cache_path ${API_UWSGI_CACHE_PATH} levels=1:2 keys_zone=api_cache_${PROJECT_NAME}:8m inactive=2w max_size=${API_UWSGI_CACHE_SIZE};
+uwsgi_cache_path ${API_UWSGI_CACHE_PATH} levels=1:2 keys_zone=${WWW_UWSGI_CACHE_ZONE}:8m inactive=2w max_size=${API_UWSGI_CACHE_SIZE};
 
 server {
     listen 80;

--- a/conf.mk
+++ b/conf.mk
@@ -29,7 +29,7 @@ WWW_SERVER_ALIASES ?=
 ifeq ($(PROJECT_MODE),development)
     WWW_UWSGI_CACHE_ZONE ?= off
 else
-    WWW_UWSGI_CACHE_ZONE ?= api_cache
+    WWW_UWSGI_CACHE_ZONE ?= api_cache_${PROJECT_NAME}
 endif
 WWW_UWSGI_TIMEOUT ?= 5m
 # Make a guess at branch name, since production instances will be detached HEAD

--- a/docs/advanced/development.rst
+++ b/docs/advanced/development.rst
@@ -48,7 +48,7 @@ Branching and publishing to live
 
 The CLiC project has several long-lived branches:
 
-development
+test
     The default branch, the test server will run this version of the CLiC code.
     Documentation updates should be done directly in this branch.
     Code updates should be done in a feature branch and merged with a pull request.


### PR DESCRIPTION
It stopped when we renamed the branch, put it back.