### PR TITLE
Never allow speculative updates for flexiconc / keywords

### DIFF
--- a/client/lib/page_keyword.js
+++ b/client/lib/page_keyword.js
@@ -67,6 +67,11 @@ PageKeyword.prototype.reload_data = function reload(page_state) {
         throw new DisplayError("Please select a reference subset", "warn");
     }
 
+    if (page_state.speculative) {
+        // Don't allow speculative updates, block behind confirm button
+        throw new DisplayError("Confirm to continue processing", "confirm");
+    }
+
     return this.cached_get('keyword', api_opts).then(this.post_process.bind(this, page_state));
 };
 

--- a/flexiclic/flexiclic/flexiclic.py
+++ b/flexiclic/flexiclic/flexiclic.py
@@ -93,12 +93,12 @@ class FlexiClic():
         else:
             opts, annotations, annotations_requires = path_util.normalize_source(opts, annotations, self._available_algorithms())
 
-            if self._flexiconc and self._source_opts == opts and self._source_annotations == annotations:
+            if speculative:
+                # We don't ever allow speculative updates in flexiconc
+                raise errors.UserConfirmError()
+            elif self._flexiconc and self._source_opts == opts and self._source_annotations == annotations:
                 # Previous object available and matches, recycle
                 concordance = self._flexiconc
-            elif speculative:
-                # Need to reconstruct, but not allowed yet
-                raise errors.UserConfirmError()
             else:
                 # Reconstruct self._flexiconc
                 # NB: Annotation options will get modified at some point, deepcopy now for later comparisons

--- a/flexiclic/tests/test_flexiclic.py
+++ b/flexiclic/tests/test_flexiclic.py
@@ -178,16 +178,17 @@ class TestFlexiClic(unittest.IsolatedAsyncioTestCase):
 
     async def test_compute_path_speculate(self):
         """
-        Don't recompute source concordance in speculate
+        Speculative queries always require user confirmation
         """
         with self.assertRaises(errors.UserConfirmError):
             out = [x async for x in self._compute_path(data=self.conc_data, path=[
             ], speculative=True, should_fetch=False)]
-        # After running the query, can speculate
+        # Even after running the query, speculating still requires confirmation
         out = [x async for x in self._compute_path(data=self.conc_data, path=[
         ], should_fetch=True)]
-        out = [x async for x in self._compute_path(data=self.conc_data, path=[
-        ], speculative=True, should_fetch=False)]
+        with self.assertRaises(errors.UserConfirmError):
+            out = [x async for x in self._compute_path(data=self.conc_data, path=[
+            ], speculative=True, should_fetch=False)]
 
     async def test_compute_path_nopartition(self):
         # No path, just get lines back in same order


### PR DESCRIPTION
All page updates should be intentional.

Fixes #83 