### PR TITLE
Corpora rearrangement

### DIFF
--- a/client/lib/page_contents.js
+++ b/client/lib/page_contents.js
@@ -23,9 +23,12 @@ PageContents.prototype.reload = function reload(page_state) {
         var carousel_el = self.content_el.querySelector('#content > .clic-contents > .carousel');
 
         function gen_carousel_item(d) {
+            if (!d.example_url) {
+                d.example_url = '/concordance?corpora=' + d.id;
+            }
             return [
-                '<li style="background-image: url(/api/corpora/image?corpora=' + encodeURIComponent(d.id) + '"><a href="/concordance?corpora=' + d.id + '">',
-                '  <span class="carousel-title">' + d.title + '</span>',
+                '<li style="background-image: url(/api/corpora/image?corpora=' + encodeURIComponent(d.id) + ')"><a href="' + escapeHTML(d.example_url) + '">',
+                '  <span class="carousel-title">' + escapeHTML(d.title) + '</span>',
                 '  <strong>' + d.book_count.toLocaleString() + '</strong> books,<br/>',
                 '  <strong>' + d.word_count.toLocaleString() + '</strong> total words</a>',
                 '</li>',

--- a/schema/30-corpora.sql
+++ b/schema/30-corpora.sql
@@ -9,14 +9,9 @@ CREATE TABLE IF NOT EXISTS corpus (
     UNIQUE(name),
     title TEXT NOT NULL,
     carousel_image BYTEA NULL,
-    ordering INT NOT NULL DEFAULT 0
+    ordering INT NOT NULL DEFAULT 0,
+    example_url TEXT NULL
 );
-COMMENT ON TABLE  corpus IS 'Groups of books';
-COMMENT ON COLUMN corpus.name IS 'Short name of corpus, e.g. ChiLit';
-COMMENT ON COLUMN corpus.title IS 'Title to show in interface, e.g. ''ChiLit - 19th Century Children''s Literature''';
-COMMENT ON COLUMN corpus.carousel_image IS 'Bytes of a JPEG carousel image, with a 0.4 width/height ratio';
-COMMENT ON COLUMN corpus.ordering IS 'Ordering of corpus items in interface, negative items are hidden';
-
 
 CREATE TABLE IF NOT EXISTS corpus_book (
     corpus_id INT NOT NULL,
@@ -25,7 +20,10 @@ CREATE TABLE IF NOT EXISTS corpus_book (
     FOREIGN KEY (book_id) REFERENCES book(book_id) ON DELETE CASCADE,
     PRIMARY KEY (corpus_id, book_id)
 );
-COMMENT ON TABLE  corpus_book IS 'Corpus <-> books many-to-many';
+
+-- ## Upgrades
+
+ALTER TABLE corpus ADD COLUMN IF NOT EXISTS example_url TEXT NULL;
 
 DO $$
 BEGIN
@@ -38,5 +36,15 @@ BEGIN
     END IF;
 END$$;
 
+-- ## Comments
+
+COMMENT ON TABLE  corpus IS 'Groups of books';
+COMMENT ON COLUMN corpus.name IS 'Short name of corpus, e.g. ChiLit';
+COMMENT ON COLUMN corpus.title IS 'Title to show in interface, e.g. ''ChiLit - 19th Century Children''s Literature''';
+COMMENT ON COLUMN corpus.carousel_image IS 'Bytes of a JPEG carousel image, with a 0.4 width/height ratio';
+COMMENT ON COLUMN corpus.ordering IS 'Ordering of corpus items in interface, negative items are hidden';
+COMMENT ON COLUMN corpus.example_url IS 'Example CLiC URL to demonstrate corpus';
+
+COMMENT ON TABLE  corpus_book IS 'Corpus <-> books many-to-many';
 
 COMMIT;

--- a/server/clic/db/corpus.py
+++ b/server/clic/db/corpus.py
@@ -11,37 +11,62 @@ def put_corpus(cur, corpus):
     A corpus object is a dict containing
     - name: Short name of corpus
     - title: Visible title of corpus
-    - contents: List of book names this corpus contains
+    - carousel_image_path: Filename to use for carousel image
+    - ordering: Ordering of corpus entries in DB
     """
-    # Remove any existing version of this corpus
-    cur.execute("""
-        DELETE FROM corpus WHERE name = %(name)s;
-    """, corpus)
-
+    # Replace image path with image content
     if corpus.get('carousel_image_path', None):
         with open(corpus['carousel_image_path'], 'rb') as f:
             corpus['carousel_image'] = f.read()
     else:
         corpus['carousel_image'] = None
 
-    # Add main entry
+    # Insert, or update existing entry with matching name
     cur.execute("""
         INSERT INTO corpus (name, title, carousel_image, ordering)
              VALUES (%(name)s, %(title)s, %(carousel_image)s, %(ordering)s)
+        ON CONFLICT (name) DO UPDATE
+                SET title = EXCLUDED.title
+                  , carousel_image = EXCLUDED.carousel_image
+                  , ordering = EXCLUDED.ordering
           RETURNING corpus_id
     """, corpus)
     (corpus_id,) = cur.fetchone()
 
-    # Add links to books
+    for b in corpus.get("contents", []):
+        add_book_to_corpus(cur, corpus, dict(name=b))
+
+
+def add_book_to_corpus(cur, corpus, book):
+    """
+    Add a book to a corpus (i.e. a set of books) in the database.
+
+    A corpus object is a dict containing
+    - name: Short name of corpus
+
+    A book object is a dict containing
+    - name: The shortname of the book
+    """
+    # Find corpus & book ID
+    cur.execute("""
+        SELECT corpus_id
+          FROM corpus
+         WHERE name = %(name)s
+    """, dict(name=corpus['name']))
+    (corpus_id,) = cur.fetchone()
+    cur.execute("""
+        SELECT book_id
+          FROM book
+         WHERE name = %(name)s
+    """, dict(name=book['name']))
+    (book_id,) = cur.fetchone()
+
+    # Add link, ignore if already present
     cur.execute("""
         INSERT INTO corpus_book (corpus_id, book_id)
-             SELECT %(corpus_id)s corpus_id
-                  , b.book_id
-               FROM book b
-              WHERE b.name IN %(book_names)s
+             VALUES (%(corpus_id)s, %(book_id)s)
+        ON CONFLICT (corpus_id, book_id) DO NOTHING
     """, dict(
         corpus_id=corpus_id,
-        book_names=tuple(corpus['contents'])
+        book_id=book_id,
     ))
-    if cur.rowcount != len(corpus['contents']):
-        raise ValueError("Not all books in corpus exist in database %s" % corpus['contents'])

--- a/server/clic/db/corpus.py
+++ b/server/clic/db/corpus.py
@@ -13,6 +13,7 @@ def put_corpus(cur, corpus):
     - title: Visible title of corpus
     - carousel_image_path: Filename to use for carousel image
     - ordering: Ordering of corpus entries in DB
+    - example_url: An example CLiC URL to use in the carousel. Hostname will be stripped
     """
     # Replace image path with image content
     if corpus.get('carousel_image_path', None):
@@ -21,14 +22,20 @@ def put_corpus(cur, corpus):
     else:
         corpus['carousel_image'] = None
 
+    if corpus.get('example_url', None):
+        corpus["example_url"] = corpus["example_url"].replace("https://clic-fiction.com/", "/")
+    else:
+        corpus["example_url"] = None
+
     # Insert, or update existing entry with matching name
     cur.execute("""
-        INSERT INTO corpus (name, title, carousel_image, ordering)
-             VALUES (%(name)s, %(title)s, %(carousel_image)s, %(ordering)s)
+        INSERT INTO corpus (name, title, carousel_image, ordering, example_url)
+             VALUES (%(name)s, %(title)s, %(carousel_image)s, %(ordering)s, %(example_url)s)
         ON CONFLICT (name) DO UPDATE
                 SET title = EXCLUDED.title
                   , carousel_image = EXCLUDED.carousel_image
                   , ordering = EXCLUDED.ordering
+                  , example_url = EXCLUDED.example_url
           RETURNING corpus_id
     """, corpus)
     (corpus_id,) = cur.fetchone()

--- a/server/clic/metadata.py
+++ b/server/clic/metadata.py
@@ -71,6 +71,7 @@ def corpora_headlines(cur):
     cur.execute("""
         SELECT c.name
              , c.title
+             , c.example_url
              , COUNT(*) book_count
              , SUM((
                  SELECT SUM(word_count)
@@ -87,10 +88,11 @@ def corpora_headlines(cur):
     ))
 
     out = []
-    for (c_id, c_title, book_count, word_count) in cur:
+    for (c_id, c_title, example_url, book_count, word_count) in cur:
         out.append(dict(
             id='corpus:%s' % c_id,
             title=c_title,
+            example_url=example_url,
             book_count=book_count,
             word_count=word_count,
         ))

--- a/server/clic/migrate/corpora_repo.py
+++ b/server/clic/migrate/corpora_repo.py
@@ -41,18 +41,16 @@ def parse_corpora_bib(corpora_dir, bib_name='corpora.bib'):
 
 def get_corpora_for(book_paths):
     """
-    Return all corpora objects that contain the books in book_paths
+    Return a mapping from book_path to the associated corpora object
     """
-    wanted_books = set(os.path.splitext(os.path.basename(p))[0] for p in book_paths)
-
     # Assume all books sit in the same root
     corpora_dir = os.path.dirname(os.path.dirname(book_paths[0]))
-    corpora = parse_corpora_bib(corpora_dir)
+    corpora = {c['name']: c for c in parse_corpora_bib(corpora_dir)}
 
-    # For each corpora, return it if it's contents are part of wanted_books
-    for c in corpora:
-        if not wanted_books.isdisjoint(c['contents']):
-            yield c
+    return {
+        p: corpora[os.path.basename(os.path.dirname(p))]
+        for p in book_paths
+    }
 
 
 def to_region_file(book_path):
@@ -107,7 +105,7 @@ def script_import_corpora_repo():
     import sys
     import timeit
     from ..db.book import put_book
-    from ..db.corpus import put_corpus
+    from ..db.corpus import put_corpus, add_book_to_corpus
     from ..db.cursor import get_script_cursor
     from ..db.version import update_version
     from ..region.tag import tagger
@@ -124,21 +122,27 @@ def script_import_corpora_repo():
         print("No books to insert.")
         sys.exit(0)
 
+    book_path_to_corpus = get_corpora_for(book_paths)
+
     with get_script_cursor(for_write=True) as cur:
+        # Ensure corpora exist. The bib's 'contents' is ignored here; the
+        # script links books to corpora itself, per-book, below.
+        seen_corpora = set()
+        for c in book_path_to_corpus.values():
+            if c['name'] in seen_corpora:
+                continue
+            put_corpus(cur, {k: v for k, v in c.items() if k != 'contents'})
+            seen_corpora.add(c['name'])
+
         for p in book_paths:
             print("* %s" % p, end=" ", flush=True)
             start_time = timeit.default_timer()
             book = import_book(p)  # Read book and/or regions file
             tagger(book)  # Fill in any remaining regions
             put_book(cur, book, force=args.force)  # Write to DB
+            add_book_to_corpus(cur, book_path_to_corpus[p], book)
             print("%.2f secs" % (timeit.default_timer() - start_time))
             cur.connection.commit()
-
-        for c in get_corpora_for(book_paths):
-            print("* corpora:%s" % c['name'], end=" ", flush=True)
-            start_time = timeit.default_timer()
-            put_corpus(cur, c)
-            print("%.2f secs" % (timeit.default_timer() - start_time))
 
         if len(book_paths) > 0:
             # Update DB versions to match current CLiC & corpora repo.

--- a/server/clic/migrate/corpora_repo.py
+++ b/server/clic/migrate/corpora_repo.py
@@ -32,6 +32,7 @@ def parse_corpora_bib(corpora_dir, bib_name='corpora.bib'):
             corpora[c_id]['description'] = lt2txt.latex_to_text(entry.fields.get('abstract', ''))
             corpora[c_id]['carousel_image_path'] = carousel_image_path
             corpora[c_id]['ordering'] = int(lt2txt.latex_to_text(entry.fields['number']))
+            corpora[c_id]['example_url'] = lt2txt.latex_to_text(entry.fields['example_url']) if 'example_url' in entry.fields else None
         else:
             for kw in keywords:
                 corpora[kw]['contents'].append(lt2txt.latex_to_text(entry.fields['shorttitle']))

--- a/server/tests/requires_run_script.py
+++ b/server/tests/requires_run_script.py
@@ -1,0 +1,25 @@
+import contextlib
+import sys
+from unittest import mock
+
+
+class RequiresRunScript():
+    """
+    Mixin (combine with RequiresPostgresql) to drive a clic CLI script
+    entry point against the test database.
+    """
+    def run_script(self, script_fn, *argv):
+        """
+        Invoke (script_fn) with sys.argv set to [name, *argv], routing any
+        get_script_cursor() it opens to the test PG cursor.
+        """
+        cur = self.pg_cur()
+
+        @contextlib.contextmanager
+        def fake_cursor(for_write=False):
+            yield cur
+
+        fake_argv = [script_fn.__name__] + list(argv)
+        with mock.patch.object(sys, 'argv', fake_argv), \
+             mock.patch('clic.db.cursor.get_script_cursor', fake_cursor):
+            script_fn()

--- a/server/tests/test_db_corpus.py
+++ b/server/tests/test_db_corpus.py
@@ -1,0 +1,137 @@
+import os
+import tempfile
+import unittest
+
+from clic.db.corpus import add_book_to_corpus, put_corpus
+
+from .requires_postgresql import RequiresPostgresql
+
+
+class Test_put_corpus(RequiresPostgresql, unittest.TestCase):
+    def _corpus_id(self, cur, name):
+        cur.execute("SELECT corpus_id FROM corpus WHERE name = %s", (name,))
+        (corpus_id,) = cur.fetchone()
+        return corpus_id
+
+    def test_insert(self):
+        """put_corpus inserts a new row"""
+        cur = self.pg_cur()
+        put_corpus(cur, dict(
+            name="ut_corp_insert",
+            title="UT corpus insert",
+            ordering=3,
+        ))
+
+        cur.execute("""
+            SELECT name, title, ordering, carousel_image
+              FROM corpus WHERE name = %s
+        """, ("ut_corp_insert",))
+        self.assertEqual(cur.fetchone(), (
+            "ut_corp_insert", "UT corpus insert", 3, None,
+        ))
+
+    def test_update_existing(self):
+        """Re-inserting with same name updates title/ordering, keeps corpus_id"""
+        cur = self.pg_cur()
+        put_corpus(cur, dict(
+            name="ut_corp_update",
+            title="initial title",
+            ordering=1,
+        ))
+        first_id = self._corpus_id(cur, "ut_corp_update")
+        put_corpus(cur, dict(
+            name="ut_corp_update",
+            title="updated title",
+            ordering=9,
+        ))
+        second_id = self._corpus_id(cur, "ut_corp_update")
+        self.assertEqual(first_id, second_id)
+
+        cur.execute("""
+            SELECT title, ordering FROM corpus WHERE corpus_id = %s
+        """, (first_id,))
+        self.assertEqual(cur.fetchone(), ("updated title", 9))
+
+    def test_carousel_image_from_path(self):
+        """carousel_image_path is read in as carousel_image bytes"""
+        cur = self.pg_cur()
+
+        with tempfile.NamedTemporaryFile(delete=False) as f:
+            f.write(b"\x89PNG\r\nfake-image-bytes")
+            image_path = f.name
+        try:
+            put_corpus(cur, dict(
+                name="ut_corp_image",
+                title="UT corpus image",
+                ordering=0,
+                carousel_image_path=image_path,
+            ))
+        finally:
+            os.unlink(image_path)
+
+        cur.execute("""
+            SELECT carousel_image FROM corpus WHERE name = %s
+        """, ("ut_corp_image",))
+        (image,) = cur.fetchone()
+        self.assertEqual(bytes(image), b"\x89PNG\r\nfake-image-bytes")
+
+    def test_no_carousel_image(self):
+        """An absent / falsy carousel_image_path results in NULL"""
+        cur = self.pg_cur()
+
+        # Key missing entirely
+        put_corpus(cur, dict(
+            name="ut_corp_noimg_a",
+            title="UT corpus no image a",
+            ordering=0,
+        ))
+        cur.execute("SELECT carousel_image FROM corpus WHERE name = %s", ("ut_corp_noimg_a",))
+        self.assertEqual(cur.fetchone(), (None,))
+
+        # Key present but None
+        put_corpus(cur, dict(
+            name="ut_corp_noimg_b",
+            title="UT corpus no image b",
+            ordering=0,
+            carousel_image_path=None,
+        ))
+        cur.execute("SELECT carousel_image FROM corpus WHERE name = %s", ("ut_corp_noimg_b",))
+        self.assertEqual(cur.fetchone(), (None,))
+
+
+class Test_add_book_to_corpus(RequiresPostgresql, unittest.TestCase):
+    def _book_ids_in(self, cur, corpus_name):
+        cur.execute("""
+            SELECT b.name
+              FROM corpus c
+              JOIN corpus_book cb ON cb.corpus_id = c.corpus_id
+              JOIN book b ON b.book_id = cb.book_id
+             WHERE c.name = %s
+          ORDER BY b.name
+        """, (corpus_name,))
+        return [r[0] for r in cur.fetchall()]
+
+    def test_add(self):
+        """add_book_to_corpus links a book to a corpus"""
+        cur = self.pg_cur()
+        self.put_books(
+            ut_a2c_one="Book one\nA Author\n\nHello.",
+            ut_a2c_two="Book two\nA Author\n\nWorld.",
+        )
+        self.put_corpora(dict(name="ut_a2c_corp"))
+
+        add_book_to_corpus(cur, dict(name="ut_a2c_corp"), dict(name="ut_a2c_one"))
+        self.assertEqual(self._book_ids_in(cur, "ut_a2c_corp"), ["ut_a2c_one"])
+
+        add_book_to_corpus(cur, dict(name="ut_a2c_corp"), dict(name="ut_a2c_two"))
+        self.assertEqual(self._book_ids_in(cur, "ut_a2c_corp"), ["ut_a2c_one", "ut_a2c_two"])
+
+    def test_idempotent(self):
+        """Re-adding the same book is a no-op (no error, no duplicate row)"""
+        cur = self.pg_cur()
+        self.put_books(ut_a2c_idem="Book\nA Author\n\nHello.")
+        self.put_corpora(dict(name="ut_a2c_idem_corp"))
+
+        add_book_to_corpus(cur, dict(name="ut_a2c_idem_corp"), dict(name="ut_a2c_idem"))
+        add_book_to_corpus(cur, dict(name="ut_a2c_idem_corp"), dict(name="ut_a2c_idem"))
+        self.assertEqual(self._book_ids_in(cur, "ut_a2c_idem_corp"), ["ut_a2c_idem"])

--- a/server/tests/test_db_corpus.py
+++ b/server/tests/test_db_corpus.py
@@ -98,6 +98,93 @@ class Test_put_corpus(RequiresPostgresql, unittest.TestCase):
         cur.execute("SELECT carousel_image FROM corpus WHERE name = %s", ("ut_corp_noimg_b",))
         self.assertEqual(cur.fetchone(), (None,))
 
+    def test_example_url(self):
+        """example_url is stored, and clic-fiction.com hostname stripped"""
+        cur = self.pg_cur()
+
+        # Full clic-fiction.com URL is rewritten to a relative path
+        put_corpus(cur, dict(
+            name="ut_corp_url_full",
+            title="UT corpus url full",
+            ordering=0,
+            example_url="https://clic-fiction.com/concordance?corpora=dickens",
+        ))
+        cur.execute("SELECT example_url FROM corpus WHERE name = %s", ("ut_corp_url_full",))
+        self.assertEqual(cur.fetchone(), ("/concordance?corpora=dickens",))
+
+        # A URL to another host is left alone
+        put_corpus(cur, dict(
+            name="ut_corp_url_other",
+            title="UT corpus url other",
+            ordering=0,
+            example_url="https://example.com/somewhere",
+        ))
+        cur.execute("SELECT example_url FROM corpus WHERE name = %s", ("ut_corp_url_other",))
+        self.assertEqual(cur.fetchone(), ("https://example.com/somewhere",))
+
+        # An already-relative URL is left alone
+        put_corpus(cur, dict(
+            name="ut_corp_url_rel",
+            title="UT corpus url rel",
+            ordering=0,
+            example_url="/concordance?corpora=other",
+        ))
+        cur.execute("SELECT example_url FROM corpus WHERE name = %s", ("ut_corp_url_rel",))
+        self.assertEqual(cur.fetchone(), ("/concordance?corpora=other",))
+
+    def test_no_example_url(self):
+        """An absent / falsy example_url results in NULL"""
+        cur = self.pg_cur()
+
+        # Key missing entirely
+        put_corpus(cur, dict(
+            name="ut_corp_nourl_a",
+            title="UT corpus no url a",
+            ordering=0,
+        ))
+        cur.execute("SELECT example_url FROM corpus WHERE name = %s", ("ut_corp_nourl_a",))
+        self.assertEqual(cur.fetchone(), (None,))
+
+        # Key present but None
+        put_corpus(cur, dict(
+            name="ut_corp_nourl_b",
+            title="UT corpus no url b",
+            ordering=0,
+            example_url=None,
+        ))
+        cur.execute("SELECT example_url FROM corpus WHERE name = %s", ("ut_corp_nourl_b",))
+        self.assertEqual(cur.fetchone(), (None,))
+
+    def test_update_example_url(self):
+        """Re-inserting overwrites example_url, including clearing to NULL"""
+        cur = self.pg_cur()
+        put_corpus(cur, dict(
+            name="ut_corp_url_upd",
+            title="UT corpus url upd",
+            ordering=0,
+            example_url="https://clic-fiction.com/first",
+        ))
+        cur.execute("SELECT example_url FROM corpus WHERE name = %s", ("ut_corp_url_upd",))
+        self.assertEqual(cur.fetchone(), ("/first",))
+
+        put_corpus(cur, dict(
+            name="ut_corp_url_upd",
+            title="UT corpus url upd",
+            ordering=0,
+            example_url="https://clic-fiction.com/second",
+        ))
+        cur.execute("SELECT example_url FROM corpus WHERE name = %s", ("ut_corp_url_upd",))
+        self.assertEqual(cur.fetchone(), ("/second",))
+
+        # Dropping the key back to nothing NULLs the column again
+        put_corpus(cur, dict(
+            name="ut_corp_url_upd",
+            title="UT corpus url upd",
+            ordering=0,
+        ))
+        cur.execute("SELECT example_url FROM corpus WHERE name = %s", ("ut_corp_url_upd",))
+        self.assertEqual(cur.fetchone(), (None,))
+
 
 class Test_add_book_to_corpus(RequiresPostgresql, unittest.TestCase):
     def _book_ids_in(self, cur, corpus_name):

--- a/server/tests/test_metadata.py
+++ b/server/tests/test_metadata.py
@@ -112,7 +112,11 @@ It was an iron bar
             """.strip(),
         )
         self.put_corpora(
-            dict(name="zcorp", contents=['ut_corpora_3', 'ut_corpora_2']),
+            dict(
+                name="zcorp",
+                contents=['ut_corpora_3', 'ut_corpora_2'],
+                example_url="https://clic-fiction.com/concordance?corpora=zcorp",
+            ),
             dict(name="acorp", contents=['ut_corpora_1']),
         )
         out = corpora_headlines(self.pg_cur())
@@ -120,12 +124,16 @@ It was an iron bar
             {
                 "id": "corpus:zcorp",
                 "title": "UT corpus zcorp",
+                # example_url passed through put_corpus, with clic-fiction.com stripped
+                "example_url": "/concordance?corpora=zcorp",
                 "book_count": 2,
                 "word_count": 8,
             },
             {
                 "id": "corpus:acorp",
                 "title": "UT corpus acorp",
+                # No example_url specified, so returned as None
+                "example_url": None,
                 "book_count": 1,
                 "word_count": 6,
             },

--- a/server/tests/test_migrate_corpora_repo.py
+++ b/server/tests/test_migrate_corpora_repo.py
@@ -1,9 +1,21 @@
 import csv
+import os
 import os.path
 import tempfile
 import unittest
+from unittest import mock
 
-from clic.migrate.corpora_repo import parse_corpora_bib, import_book, export_book
+from clic.migrate import corpora_repo
+from clic.migrate.corpora_repo import (
+    export_book,
+    get_corpora_for,
+    import_book,
+    parse_corpora_bib,
+    to_region_file,
+)
+
+from .requires_postgresql import RequiresPostgresql
+from .requires_run_script import RequiresRunScript
 
 
 class RequiresCorporaDir():
@@ -176,3 +188,211 @@ class Test_parse_corpora_bib(unittest.TestCase, RequiresCorporaDir):
                 contents=['gulliver', 'toadylion'],
             ),
         ])
+
+
+class Test_to_region_file(unittest.TestCase):
+    def test_call(self):
+        """to_region_file swaps the book extension for .regions.csv"""
+        self.assertEqual(
+            to_region_file('/some/dir/book1.txt'),
+            '/some/dir/book1.regions.csv',
+        )
+        # Works with relative paths too
+        self.assertEqual(
+            to_region_file('book2.txt'),
+            'book2.regions.csv',
+        )
+        # Only the final extension is replaced
+        self.assertEqual(
+            to_region_file('/a/b.c/book3.txt'),
+            '/a/b.c/book3.regions.csv',
+        )
+
+
+CORPORA_BIB = """
+@book{anstey_brass_1900,
+        title = {The Brass Bottle},
+        shorttitle = {brass},
+        author = {Anstey, F.},
+        date = {1900},
+        keywords = {{ChiLit}}
+}
+
+@book{crockett_surprising_1897,
+        title = {Sir Toady Lion},
+        shorttitle = {toadylion},
+        author = {Crockett, S. R.},
+        date = {1897},
+        keywords = {{ChiLit}}
+}
+
+@book{swift_gullivers_1726,
+        title = {Gulliver's Travels},
+        shorttitle = {gulliver},
+        author = {Swift, Jonathan},
+        date = {1726},
+        keywords = {{ArTs}}
+}
+
+@book{cermakova_childrens_2017,
+        title = {Children's Literature},
+        shorttitle = {{ChiLit}},
+        number = {3},
+        author = {Čermáková, A.},
+        date = {2017},
+        keywords = {corpus}
+}
+
+@book{mahlberg_additional_2017,
+        title = {Additional Requested Texts},
+        shorttitle = {{ArTs}},
+        number = {4},
+        author = {Mahlberg, M.},
+        date = {2017},
+        keywords = {corpus}
+}
+""".strip()
+
+
+class Test_get_corpora_for(unittest.TestCase, RequiresCorporaDir):
+    maxDiff = None
+
+    def test_call(self):
+        """
+        get_corpora_for returns a {book_path: corpus_dict} mapping,
+        looking up the corpus by the book's parent-directory name.
+        """
+        corpora_dir = self.corpora_dir({
+            'corpora.bib': CORPORA_BIB,
+            'ChiLit/brass.txt': "Moo.",
+            'ChiLit/toadylion.txt': "Oink.",
+            'ArTs/gulliver.txt': "Baa.",
+        })
+        brass_path = os.path.join(corpora_dir, 'ChiLit', 'brass.txt')
+        toady_path = os.path.join(corpora_dir, 'ChiLit', 'toadylion.txt')
+        gulliver_path = os.path.join(corpora_dir, 'ArTs', 'gulliver.txt')
+
+        out = get_corpora_for([brass_path, toady_path, gulliver_path])
+
+        # ChiLit books share the same corpus dict; ArTs has its own
+        self.assertEqual(set(out.keys()), {brass_path, toady_path, gulliver_path})
+        self.assertIs(out[brass_path], out[toady_path])
+        self.assertIsNot(out[brass_path], out[gulliver_path])
+        self.assertEqual(out[brass_path]['name'], 'ChiLit')
+        self.assertEqual(out[gulliver_path]['name'], 'ArTs')
+
+    def test_subset(self):
+        """Only requested books appear in the output, but corpora are fully populated"""
+        corpora_dir = self.corpora_dir({
+            'corpora.bib': CORPORA_BIB,
+            'ChiLit/brass.txt': "Moo.",
+            'ChiLit/toadylion.txt': "Oink.",
+            'ArTs/gulliver.txt': "Baa.",
+        })
+        brass_path = os.path.join(corpora_dir, 'ChiLit', 'brass.txt')
+
+        out = get_corpora_for([brass_path])
+        self.assertEqual(list(out.keys()), [brass_path])
+        # The corpus's contents list still reflects everything in the .bib,
+        # not just the requested subset
+        self.assertEqual(sorted(out[brass_path]['contents']), ['brass', 'toadylion'])
+
+
+class Test_script_import_corpora_repo(
+    RequiresPostgresql, RequiresRunScript, RequiresCorporaDir, unittest.TestCase,
+):
+    maxDiff = None
+
+    def setUp(self):
+        super().setUp()
+        # Tests assert on the full content of the book / corpus tables,
+        # so start from an empty DB each time.
+        cur = self.pg_cur()
+        cur.execute("TRUNCATE book, corpus RESTART IDENTITY CASCADE")
+        cur.connection.commit()
+
+        # update_version shells out to `git rev-parse` against a directory
+        # that isn't a git repo in our temp fixtures, so stub it out.
+        p = mock.patch('clic.db.version.update_version')
+        p.start()
+        self.addCleanup(p.stop)
+
+    def _all_book_names(self):
+        cur = self.pg_cur()
+        cur.execute("SELECT name FROM book ORDER BY name")
+        return [r[0] for r in cur.fetchall()]
+
+    def _books_in_corpus(self, corpus_name):
+        cur = self.pg_cur()
+        cur.execute("""
+            SELECT b.name
+              FROM corpus c
+              JOIN corpus_book cb ON cb.corpus_id = c.corpus_id
+              JOIN book b ON b.book_id = cb.book_id
+             WHERE c.name = %s
+          ORDER BY b.name
+        """, (corpus_name,))
+        return [r[0] for r in cur.fetchall()]
+
+    def test_basic(self):
+        """Each book is inserted and added to the corpus matching its parent dir"""
+        corpora_dir = self.corpora_dir({
+            'corpora.bib': CORPORA_BIB,
+            'ChiLit/brass.txt': "Brass Bottle\nF Anstey\n\nMoo, said the cow.",
+            'ChiLit/toadylion.txt': "Toady Lion\nS R Crockett\n\nOink, said the pig.",
+            'ArTs/gulliver.txt': "Gulliver\nJ Swift\n\nBaa, said the sheep.",
+        })
+
+        self.run_script(
+            corpora_repo.script_import_corpora_repo,
+            os.path.join(corpora_dir, 'ChiLit', 'brass.txt'),
+            os.path.join(corpora_dir, 'ChiLit', 'toadylion.txt'),
+            os.path.join(corpora_dir, 'ArTs', 'gulliver.txt'),
+        )
+
+        self.assertEqual(self._all_book_names(), ['brass', 'gulliver', 'toadylion'])
+        self.assertEqual(self._books_in_corpus('ChiLit'), ['brass', 'toadylion'])
+        self.assertEqual(self._books_in_corpus('ArTs'), ['gulliver'])
+
+    def test_directory_argument(self):
+        """A single directory argument is expanded to its *.txt files"""
+        corpora_dir = self.corpora_dir({
+            'corpora.bib': CORPORA_BIB,
+            'ChiLit/brass.txt': "Brass Bottle\nF Anstey\n\nMoo, said the cow.",
+            'ChiLit/toadylion.txt': "Toady Lion\nS R Crockett\n\nOink, said the pig.",
+        })
+
+        self.run_script(
+            corpora_repo.script_import_corpora_repo,
+            os.path.join(corpora_dir, 'ChiLit'),
+        )
+
+        self.assertEqual(self._all_book_names(), ['brass', 'toadylion'])
+        self.assertEqual(self._books_in_corpus('ChiLit'), ['brass', 'toadylion'])
+
+    def test_symlink_in_two_corpora(self):
+        """
+        A book symlinked into a second corpus directory is ingested once,
+        but linked to both corpora.
+        """
+        corpora_dir = self.corpora_dir({
+            'corpora.bib': CORPORA_BIB,
+            'ChiLit/brass.txt': "Brass Bottle\nF Anstey\n\nMoo, said the cow.",
+        })
+        os.makedirs(os.path.join(corpora_dir, 'ArTs'))
+        os.symlink(
+            os.path.join(corpora_dir, 'ChiLit', 'brass.txt'),
+            os.path.join(corpora_dir, 'ArTs', 'brass.txt'),
+        )
+
+        self.run_script(
+            corpora_repo.script_import_corpora_repo,
+            os.path.join(corpora_dir, 'ChiLit', 'brass.txt'),
+            os.path.join(corpora_dir, 'ArTs', 'brass.txt'),
+        )
+
+        # Single row in book table (not duplicated)...
+        self.assertEqual(self._all_book_names(), ['brass'])
+        # ...but appears in both corpora
+        self.assertEqual(self._books_in_corpus('ChiLit'), ['brass'])
+        self.assertEqual(self._books_in_corpus('ArTs'), ['brass'])

--- a/server/tests/test_migrate_corpora_repo.py
+++ b/server/tests/test_migrate_corpora_repo.py
@@ -113,7 +113,7 @@ class Test_parse_corpora_bib(unittest.TestCase, RequiresCorporaDir):
     def test_call(self):
         corpora_dir = self.corpora_dir({
             'images/ChiLit_0.4.jpg': "JPEG!",
-            'corpora.bib': """
+            'corpora.bib': r"""
 @book{swift_gullivers_1726,
         title = {Gulliver's Travels into Several Remote Nations of the World},
         url = {https://www.gutenberg.org/ebooks/829},
@@ -134,6 +134,7 @@ class Test_parse_corpora_bib(unittest.TestCase, RequiresCorporaDir):
         publisher = {Centre for Corpus Research},
         author = {Čermáková, A. and Mahlberg, M. and Wiegand, V.},
         date = {2017},
+        example_url = {https://clic-fiction.com/toot?leap\&peep},
         keywords = {corpus}
 }
 
@@ -178,6 +179,8 @@ class Test_parse_corpora_bib(unittest.TestCase, RequiresCorporaDir):
                 description='',
                 ordering=3,
                 carousel_image_path=os.path.join(corpora_dir, 'images', 'ChiLit_0.4.jpg'),
+                # NB: Unescaped
+                example_url="https://clic-fiction.com/toot?leap&peep",
                 contents=['brass', 'toadylion'],
             ), dict(
                 name='ArTs',
@@ -185,6 +188,7 @@ class Test_parse_corpora_bib(unittest.TestCase, RequiresCorporaDir):
                 description='',
                 ordering=4,
                 carousel_image_path=None,
+                example_url=None,
                 contents=['gulliver', 'toadylion'],
             ),
         ])


### PR DESCRIPTION
Corresponding import process changes to https://github.com/mahlberg-lab/corpora/pull/5 - fill corpus entries based on directory, not corpora.bib, which we reserve for corpus metadata.

Whilst here also import / use example_urls to make carousel more interesting.

Fixes #90 